### PR TITLE
Rstudio: download .deb directly rather than using snap, as it is broken and won't launch

### DIFF
--- a/install/desktop/app-rstudio.sh
+++ b/install/desktop/app-rstudio.sh
@@ -1,1 +1,8 @@
-sudo snap install rstudio --classic
+# We were using the snap version so that we could get easier updates, but it is currently broken so we download a deb directly from the rstudio website
+#sudo snap install rstudio --classic
+
+RSTUDIO_URL="https://download1.rstudio.org/electron/jammy/amd64/rstudio-2025.05.1-513-amd64.deb"
+DOWNLOAD_DIR=$(mktemp -d)
+trap "rm -rf $DOWNLOAD_DIR" EXIT
+wget -O "$DOWNLOAD_DIR/rstudio.deb" "$RSTUDIO_URL"
+sudo apt install -y "$DOWNLOAD_DIR/rstudio.deb"


### PR DESCRIPTION
I was using a snap because it should make it easier to get the latest version, and also to update it after it is installed. Unfortunately the snap is broken, so we switch to downloading a hard-coded version directly from the rstudio website.
