### PR TITLE
Install webex and add workaround so that it launches (didn't test an actual call yet)

### DIFF
--- a/install/desktop/app-rstudio.sh
+++ b/install/desktop/app-rstudio.sh
@@ -1,8 +1,8 @@
 # We were using the snap version so that we could get easier updates, but it is currently broken so we download a deb directly from the rstudio website
 #sudo snap install rstudio --classic
 
-RSTUDIO_URL="https://download1.rstudio.org/electron/jammy/amd64/rstudio-2025.05.1-513-amd64.deb"
+DEB_URL="https://download1.rstudio.org/electron/jammy/amd64/rstudio-2025.05.1-513-amd64.deb"
 DOWNLOAD_DIR=$(mktemp -d)
 trap "rm -rf $DOWNLOAD_DIR" EXIT
-wget -O "$DOWNLOAD_DIR/rstudio.deb" "$RSTUDIO_URL"
+wget -O "$DOWNLOAD_DIR/rstudio.deb" "$DEB_URL"
 sudo apt install -y "$DOWNLOAD_DIR/rstudio.deb"

--- a/install/desktop/app-webex.sh
+++ b/install/desktop/app-webex.sh
@@ -1,0 +1,20 @@
+DEB_URL="https://binaries.webex.com/WebexDesktop-Ubuntu-Official-Package/Webex.deb"
+DOWNLOAD_DIR=$(mktemp -d)
+trap "rm -rf $DOWNLOAD_DIR" EXIT
+wget -O "$DOWNLOAD_DIR/webex.deb" "$DEB_URL"
+sudo apt install -y "$DOWNLOAD_DIR/webex.deb"
+
+# Without the following change webex will error out when launching it:
+# https://community.cisco.com/t5/webex-meetings-and-webex-app/installing-webex-app-on-ubuntu-24-04/td-p/5163446
+sudo bash -c "cat > /etc/apparmor.d/Webex" <<EOL
+abi <abi/4.0>,
+include <tunables/global>
+
+profile Webex /opt/Webex/bin/CiscoCollabHost flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/Webex>
+}
+EOL
+sudo systemctl reload apparmor


### PR DESCRIPTION
By default, webex will fail on launch after being installed from the .deb available from Cisco's website. Adding an apparmor profile works around the issue.
