### PR TITLE
Only enable wifi when wired network is not connected

### DIFF
--- a/install/terminal/set-wifi.sh
+++ b/install/terminal/set-wifi.sh
@@ -1,0 +1,21 @@
+# Disable wifi when wired networking is connected and vice versa. Avoids
+# annoying wifi-related messages when connected to the wired network in an
+# area with a weak wifi signal.
+# https://superuser.com/a/367472
+
+sudo tee /etc/NetworkManager/dispatcher.d/99-wlan >/dev/null <<'EOF'
+#!/bin/bash
+wired_interfaces="en.*|eth.*"
+if [[ "$1" =~ $wired_interfaces ]]; then
+    case "$2" in
+        up)
+            nmcli radio wifi off
+            ;;
+        down)
+            nmcli radio wifi on
+            ;;
+    esac
+fi
+EOF
+
+sudo chmod +x /etc/NetworkManager/dispatcher.d/99-wlan


### PR DESCRIPTION
This works around an annoying problem where weak wifi networks cause popups, even though a solid wired connection is actually being used.
